### PR TITLE
Handle return types

### DIFF
--- a/template/telegram-client/src/handler.rs
+++ b/template/telegram-client/src/handler.rs
@@ -63,7 +63,9 @@ impl<'a> Handler<'a> {
     match &td_type[..] {
 {% for token in tokens %}{% if token.blood and token.blood == 'Update' %}
       "{{token.name}}" => event_handler!({{token.name | td_remove_prefix(prefix='Update') | to_snake}}, {{token.name | to_camel}})(self.api, self.lout, json),
-{% endif %}{% endfor %}
+    {% elif token.is_return_type %}
+      "{{token.name}}" => event_handler!(result_{{token.name | to_snake}}, {{token.name | to_camel}})(self.api, self.lout, json),
+    {% endif %}{% endfor %}
 {% for name, td_type in listener %}{% set token = find_token(token_name = td_type) %}
       "{{token.name | to_snake | to_camel_lowercase}}" => event_handler!({{name | to_snake}}, {{token.name | to_camel}})(self.api, self.lout, json),
 {% endfor %}

--- a/template/telegram-client/src/listener.rs
+++ b/template/telegram-client/src/listener.rs
@@ -15,6 +15,7 @@ pub struct Listener {
 {% endfor %}
 
 {% for token in tokens %}{% if token.blood and token.blood == 'Update' %}  {{token.name | td_remove_prefix(prefix='Update') | to_snake}}: Option<Arc<dyn Fn((&Api, &{{token.name | to_camel}})) -> TGResult<()> + Send + Sync + 'static>>,
+{% elif token.is_return_type %}  result_{{token.name | to_snake}}: Option<Arc<dyn Fn((&Api, &{{token.name | to_camel}})) -> TGResult<()> + Send + Sync + 'static>>,
 {% endif %}{% endfor %}
 
 }
@@ -55,6 +56,13 @@ impl Listener {
   pub fn on_{{token.name | td_remove_prefix(prefix='Update') | to_snake}}<F>(&mut self, fnc: F) -> &mut Self
     where F: Fn((&Api, &{{token.name | to_camel}})) -> TGResult<()> + Send + Sync + 'static {
     self.{{token.name | td_remove_prefix(prefix='Update') | to_snake}} = Some(Arc::new(fnc));
+    self
+  }
+{% elif token.is_return_type %}
+  /// {{token.description}}
+  pub fn on_result_{{token.name | to_snake}}<F>(&mut self, fnc: F) -> &mut Self
+    where F: Fn((&Api, &{{token.name | to_camel}})) -> TGResult<()> + Send + Sync + 'static {
+    self.result_{{token.name | to_snake}} = Some(Arc::new(fnc));
     self
   }
 {% endif %}{% endfor %}
@@ -107,6 +115,11 @@ impl Lout {
   /// {{token.description}}
   pub fn {{token.name | td_remove_prefix(prefix='Update') | to_snake}}(&self) -> &Option<Arc<dyn Fn((&Api, &{{token.name | to_camel}})) -> TGResult<()> + Send + Sync + 'static>> {
     &self.listener.{{token.name | td_remove_prefix(prefix='Update') | to_snake}}
+  }
+{% elif token.is_return_type %}
+  /// {{token.description}}
+  pub fn result_{{token.name | to_snake}}(&self) -> &Option<Arc<dyn Fn((&Api, &{{token.name | to_camel}})) -> TGResult<()> + Send + Sync + 'static>> {
+    &self.listener.result_{{token.name | to_snake}}
   }
 {% endif %}{% endfor %}
 }

--- a/tl-parser/src/types/outer.rs
+++ b/tl-parser/src/types/outer.rs
@@ -43,6 +43,9 @@ pub struct TLTokenGroup {
   ///      type is trait, blood is none
   ///      type is function, blood is return type
   pub(crate) blood: Option<String>,
+  /// when type is struct, this may be true to
+  /// indicate this can be returned be a function
+  pub(crate) is_return_type: bool
 }
 
 impl TLTokenGroup {
@@ -52,6 +55,7 @@ impl TLTokenGroup {
   pub fn arguments       (&self) -> Vec<TLTokenArgType>            { self.arguments      .clone() }
   pub fn type_           (&self) -> TLTokenGroupType               { self.type_          .clone() }
   pub fn blood           (&self) -> Option<String>                 { self.blood          .clone() }
+  pub fn is_return_type  (&self) -> bool                           { self.is_return_type .clone() }
 }
 
 impl TLTokenArgType {


### PR DESCRIPTION
**Why?**

Some TDLib functions asynchronously return data (e.g. `getChatHistory`, `getMessages`, `getChats`). Currently, there is no way to listen for the returned data and handle it. 
(This is in response to https://github.com/fewensa/telegram-client/issues/14)

**What?**

This PR introduces a new field `is_return_type` for `TLGroupToken`. The function `token_group` (tl.rs, l. 9)  is changed so that whenever it sees a return type of a function it sets the `is_return_type` for the corresponding struct token group to `true`. Later, when writing the files for `telegram_client` this is used to create appropriate event handlers and listeners.